### PR TITLE
Declare Breaks&Replaces against printer-driver-hpcups (<< 3.26.4+dfsg0-1~)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+hplip (3.26.4+dfsg0-1deepin2) unstable; urgency=medium
+
+  * Declare Breaks&Replaces against printer-driver-hpcups (<<
+    3.26.4+dfsg0-1~)
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Thu, 09 Jul 2026 13:57:05 +0800
+
 hplip (3.26.4+dfsg0-1deepin1) unstable; urgency=medium
 
   * Apply previous changes:

--- a/debian/control
+++ b/debian/control
@@ -68,6 +68,10 @@ Suggests:
  hplip-gui,
  python3-notify2,
  system-config-printer,
+Breaks:
+ printer-driver-hpcups (<< 3.26.4+dfsg0-1~)
+Replaces:
+ printer-driver-hpcups (<< 3.26.4+dfsg0-1~)
 Description: HP Linux Printing and Imaging System (HPLIP)
  The HP Linux Printing and Imaging System provides full support for
  printing on most HP SFP (single function peripheral) inkjets and many


### PR DESCRIPTION
/usr/lib/cups/filter/hpcdmfax was in printer-driver-hpcups/3.24.4+dfsg0-0ubuntu5deepin1
